### PR TITLE
added usegmtime to cel_odbc.conf

### DIFF
--- a/etc/asterisk/cel_odbc.d/01-wazo.conf
+++ b/etc/asterisk/cel_odbc.d/01-wazo.conf
@@ -1,3 +1,4 @@
 [xivo]
 connection = xivo
 table = cel
+usegmtime=yes


### PR DESCRIPTION
All CELs will use UTC. Now, timezone can be inferred.