### PR TITLE
Revert "added usegmtime to cel_odbc.conf"

### DIFF
--- a/etc/asterisk/cel_odbc.d/01-wazo.conf
+++ b/etc/asterisk/cel_odbc.d/01-wazo.conf
@@ -1,4 +1,3 @@
 [xivo]
 connection = xivo
 table = cel
-usegmtime=yes


### PR DESCRIPTION
The change to the column type fixes the problem and adding usegmt here adds an undesirable offset to the inserted date time.