### PR TITLE
http.conf: allow up to 1000 HTTP sessions

### DIFF
--- a/etc/asterisk/http.d/01-wazo.conf
+++ b/etc/asterisk/http.d/01-wazo.conf
@@ -8,3 +8,4 @@ tlsbindaddr=127.0.0.1:5040
 tlscertfile=/usr/share/xivo-certs/server.crt
 tlsprivatekey=/usr/share/xivo-certs/server.key
 servername=Wazo PBX
+sessionlimit=1000


### PR DESCRIPTION
the default limit is 100 which can be reached pretty quickly with WebRTC
sessions