### PR TITLE
managed.conf: use bindaddr 127.0.0.1

### DIFF
--- a/etc/asterisk/manager.d/99-general.conf
+++ b/etc/asterisk/manager.d/99-general.conf
@@ -2,5 +2,5 @@
 enabled = yes
 webenabled = yes
 port = 5038
-bindaddr = 0.0.0.0
+bindaddr = 127.0.0.1
 channelvars=XIVO_USERUUID,XIVO_BASE_EXTEN,WAZO_DEREFERENCED_USERUUID,WAZO_SIP_CALL_ID


### PR DESCRIPTION
the configured users can only login from 127.0.0.1 but connections are still
possible for people attempting to brute force the AMI