### PR TITLE
asterisk.service: don't block on the modules.conf generation

### DIFF
--- a/service/wazo-asterisk-config.conf
+++ b/service/wazo-asterisk-config.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPre=/bin/sh -c '/usr/bin/wazo-confgen asterisk/modules.conf > /etc/asterisk/modules.conf'
+ExecStartPre=-/bin/sh -c '/usr/bin/wazo-confgen asterisk/modules.conf > /etc/asterisk/modules.conf'


### PR DESCRIPTION
don't fail to install if wazo-confgend is not installed yet