### PR TITLE
add setgid on /etc/asterisk

### DIFF
--- a/debian/wazo-asterisk-config.postinst
+++ b/debian/wazo-asterisk-config.postinst
@@ -11,6 +11,7 @@ case "$1" in
             systemctl --system daemon-reload >/dev/null || true
             deb-systemd-invoke restart asterisk
         fi
+        chmod g+s /etc/asterisk
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
     ;;


### PR DESCRIPTION
all created files in the /etc/asterisk directory will be created with group
asterisk.

this is required for modules.conf which is created by systemd before starting
Asterisk