### PR TITLE
manager: allow dtmf events for wazo-amid

### DIFF
--- a/etc/asterisk/manager.d/01-xivo.conf
+++ b/etc/asterisk/manager.d/01-xivo.conf
@@ -10,7 +10,7 @@ write = agent,system,user
 secret = eeCho8ied3u
 deny=0.0.0.0/0.0.0.0
 permit=127.0.0.1/255.255.255.0
-read = system,call,agent,user,config,dialplan
+read = system,call,agent,user,config,dialplan,dtmf
 write = all
 
 [xivo_munin_user]


### PR DESCRIPTION
Why:

* We need it to send DTMF events to the bus.