### PR TITLE
config files: only include files ending with .conf

### DIFF
--- a/etc/asterisk/acl.conf
+++ b/etc/asterisk/acl.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the acl.d directory if you wish to modify your acl.conf
-#include acl.d/*
+#include acl.d/*.conf

--- a/etc/asterisk/agents.conf
+++ b/etc/asterisk/agents.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the agents.d directory if you wish to modify your agents.conf
-#include agents.d/*
+#include agents.d/*.conf

--- a/etc/asterisk/alsa.conf
+++ b/etc/asterisk/alsa.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the alsa.d directory if you wish to modify your alsa.conf
-#include alsa.d/*
+#include alsa.d/*.conf

--- a/etc/asterisk/ari.conf
+++ b/etc/asterisk/ari.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the ari.d directory if you wish to modify your ari.conf
-#include ari.d/*
+#include ari.d/*.conf

--- a/etc/asterisk/ccss.conf
+++ b/etc/asterisk/ccss.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the ccss.d directory if you wish to modify your ccss.conf
-#include ccss.d/*
+#include ccss.d/*.conf

--- a/etc/asterisk/cdr.conf
+++ b/etc/asterisk/cdr.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the cdr.d directory if you wish to modify your cdr.conf
-#include cdr.d/*
+#include cdr.d/*.conf

--- a/etc/asterisk/cel.conf
+++ b/etc/asterisk/cel.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the cel.d directory if you wish to modify your cel.conf
-#include cel.d/*
+#include cel.d/*.conf

--- a/etc/asterisk/cel_odbc.conf
+++ b/etc/asterisk/cel_odbc.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the cel_odbc.d directory if you wish to modify your cel_odbc.conf
-#include cel_odbc.d/*
+#include cel_odbc.d/*.conf

--- a/etc/asterisk/chan_dahdi.conf
+++ b/etc/asterisk/chan_dahdi.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the chan_dahdi.d directory if you wish to modify your chan_dahdi.conf
-#include chan_dahdi.d/*
+#include chan_dahdi.d/*.conf

--- a/etc/asterisk/confbridge.conf
+++ b/etc/asterisk/confbridge.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the confbridge.d directory if you wish to modify your confbridge.conf
-#include confbridge.d/*
+#include confbridge.d/*.conf

--- a/etc/asterisk/dundi.conf
+++ b/etc/asterisk/dundi.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the dundi.d directory if you wish to modify your dundi.conf
-#include dundi.d/*
+#include dundi.d/*.conf

--- a/etc/asterisk/enum.conf
+++ b/etc/asterisk/enum.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the enum.d directory if you wish to modify your enum.conf
-#include enum.d/*
+#include enum.d/*.conf

--- a/etc/asterisk/extconfig.conf
+++ b/etc/asterisk/extconfig.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the extconfig.d directory if you wish to modify your extconfig.conf
-#include extconfig.d/*
+#include extconfig.d/*.conf

--- a/etc/asterisk/features.conf
+++ b/etc/asterisk/features.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the features.d directory if you wish to modify your features.conf
-#include features.d/*
+#include features.d/*.conf

--- a/etc/asterisk/hep.conf
+++ b/etc/asterisk/hep.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the hep.d directory if you wish to modify your hep.conf
-#include hep.d/*
+#include hep.d/*.conf

--- a/etc/asterisk/http.conf
+++ b/etc/asterisk/http.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the http.d directory if you wish to modify your http.conf
-#include http.d/*
+#include http.d/*.conf

--- a/etc/asterisk/iax.conf
+++ b/etc/asterisk/iax.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the iax.d directory if you wish to modify your iax.conf
-#include iax.d/*
+#include iax.d/*.conf

--- a/etc/asterisk/iaxprov.conf
+++ b/etc/asterisk/iaxprov.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the iaxprov.d directory if you wish to modify your iaxprov.conf
-#include iaxprov.d/*
+#include iaxprov.d/*.conf

--- a/etc/asterisk/logger.conf
+++ b/etc/asterisk/logger.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the logger.d directory if you wish to modify your logger.conf
-#include logger.d/*
+#include logger.d/*.conf

--- a/etc/asterisk/manager.conf
+++ b/etc/asterisk/manager.conf
@@ -1,1 +1,1 @@
-#include manager.d/*
+#include manager.d/*.conf

--- a/etc/asterisk/meetme.conf
+++ b/etc/asterisk/meetme.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the meetme.d directory if you wish to modify your meetme.conf
-#include meetme.d/*
+#include meetme.d/*.conf

--- a/etc/asterisk/musiconhold.conf
+++ b/etc/asterisk/musiconhold.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the musiconhold.d directory if you wish to modify your musiconhold.conf
-#include musiconhold.d/*
+#include musiconhold.d/*.conf

--- a/etc/asterisk/oss.conf
+++ b/etc/asterisk/oss.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the oss.d directory if you wish to modify your oss.conf
-#include oss.d/*
+#include oss.d/*.conf

--- a/etc/asterisk/pbxconfig.conf
+++ b/etc/asterisk/pbxconfig.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the pbxconfig.d directory if you wish to modify your pbxconfig.conf
-#include pbxconfig.d/*
+#include pbxconfig.d/*.conf

--- a/etc/asterisk/pjsip_notify.conf
+++ b/etc/asterisk/pjsip_notify.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the pjsip_notify.d directory if you wish to modify your pjsip_notify.conf
-#include pjsip_notify.d/*
+#include pjsip_notify.d/*.conf

--- a/etc/asterisk/privacy.conf
+++ b/etc/asterisk/privacy.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the privacy.d directory if you wish to modify your privacy.conf
-#include privacy.d/*
+#include privacy.d/*.conf

--- a/etc/asterisk/queuerules.conf
+++ b/etc/asterisk/queuerules.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the queuerules.d directory if you wish to modify your queuerules.conf
-#include queuerules.d/*
+#include queuerules.d/*.conf

--- a/etc/asterisk/queues.conf
+++ b/etc/asterisk/queues.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the queues.d directory if you wish to modify your queues.conf
-#include queues.d/*
+#include queues.d/*.conf

--- a/etc/asterisk/queueskillrules.conf
+++ b/etc/asterisk/queueskillrules.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the queueskillrules.d directory if you wish to modify your queueskillrules.conf
-#include queueskillrules.d/*
+#include queueskillrules.d/*.conf

--- a/etc/asterisk/queueskills.conf
+++ b/etc/asterisk/queueskills.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the queueskills.d directory if you wish to modify your queueskills.conf
-#include queueskills.d/*
+#include queueskills.d/*.conf

--- a/etc/asterisk/res_fax.conf
+++ b/etc/asterisk/res_fax.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the res_fax.d directory if you wish to modify your res_fax.conf
-#include res_fax.d/*
+#include res_fax.d/*.conf

--- a/etc/asterisk/res_odbc.conf
+++ b/etc/asterisk/res_odbc.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the res_odbc.d directory if you wish to modify your res_odbc.conf
-#include res_odbc.d/*
+#include res_odbc.d/*.conf

--- a/etc/asterisk/res_parking.conf
+++ b/etc/asterisk/res_parking.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the res_parking.d directory if you wish to modify your res_parking.conf
-#include res_parking.d/*
+#include res_parking.d/*.conf

--- a/etc/asterisk/resolver_unbound.conf
+++ b/etc/asterisk/resolver_unbound.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the resolver_unbound.d directory if you wish to modify your resolver_unbound.conf
-#include resolver_unbound.d/*
+#include resolver_unbound.d/*.conf

--- a/etc/asterisk/rtp.conf
+++ b/etc/asterisk/rtp.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the rtp.d directory if you wish to modify your rtp.conf
-#include rtp.d/*
+#include rtp.d/*.conf

--- a/etc/asterisk/sccp.conf
+++ b/etc/asterisk/sccp.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the sccp.d directory if you wish to modify your sccp.conf
-#include sccp.d/*
+#include sccp.d/*.conf

--- a/etc/asterisk/sip.conf
+++ b/etc/asterisk/sip.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the sip.d directory if you wish to modify your sip.conf
-#include sip.d/*
+#include sip.d/*.conf

--- a/etc/asterisk/sip_notify.conf
+++ b/etc/asterisk/sip_notify.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the sip_notify.d directory if you wish to modify your sip_notify.conf
-#include sip_notify.d/*
+#include sip_notify.d/*.conf

--- a/etc/asterisk/smdi.conf
+++ b/etc/asterisk/smdi.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the smdi.d directory if you wish to modify your smdi.conf
-#include smdi.d/*
+#include smdi.d/*.conf

--- a/etc/asterisk/udptl.conf
+++ b/etc/asterisk/udptl.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the udptl.d directory if you wish to modify your udptl.conf
-#include udptl.d/*
+#include udptl.d/*.conf

--- a/etc/asterisk/voicemail.conf
+++ b/etc/asterisk/voicemail.conf
@@ -1,3 +1,3 @@
 ; This file is part of the Wazo packaging and should not be modified.
 ; Add files to the voicemail.d directory if you wish to modify your voicemail.conf
-#include voicemail.d/*
+#include voicemail.d/*.conf


### PR DESCRIPTION
Why:

* We don't want to include *.conf.dpkg-old