### PR TITLE
manager: filter out useless AMI messages for wazo_amid

### DIFF
--- a/etc/asterisk/manager.d/01-xivo.conf
+++ b/etc/asterisk/manager.d/01-xivo.conf
@@ -6,6 +6,8 @@ deny=0.0.0.0/0.0.0.0
 permit=127.0.0.1/255.255.255.0
 read = system,call,agent,user,config,dialplan,dtmf
 write = all
+eventfilter = !Event: VarSet
+eventfilter = !Event: Newexten
 
 [xivo_munin_user]
 secret = jeSwupAd0


### PR DESCRIPTION
Why:

* 50% of the AMI traffic is only caused by those two messages that are
not used anywhere in Wazo