### PR TITLE
WAZO-2816-avoid-duplicate-events

### DIFF
--- a/etc/asterisk/stasis_amqp.d/01-wazo.conf
+++ b/etc/asterisk/stasis_amqp.d/01-wazo.conf
@@ -3,4 +3,4 @@ connection = wazo             ; Connection name in amqp.conf
 exchange = wazo-headers       ; Exchange to publish to; defaults to empty string
 
 publish_ami_events = no       ; Publish AMI events to the bus (redundant with wazo-amid keep "no" to avoid duplicated events)
-publish_channel_events = yes  ; Publish all stasis channel events
+publish_channel_events = no   ; Publish all stasis channel events


### PR DESCRIPTION
At the moment all calld consumers explicitly subscribe to eventSource=channel:
using the ARI.

This makes the  publish_channel_events redundant on a Wazo.