### PR TITLE
stasis_amqp: filter unused events

### DIFF
--- a/etc/asterisk/stasis_amqp.d/01-wazo.conf
+++ b/etc/asterisk/stasis_amqp.d/01-wazo.conf
@@ -4,3 +4,5 @@ exchange = wazo-headers       ; Exchange to publish to; defaults to empty string
 
 publish_ami_events = no       ; Publish AMI events to the bus (redundant with wazo-amid keep "no" to avoid duplicated events)
 publish_channel_events = no   ; Publish all stasis channel events
+exclude_events = ChannelDialplan
+include_channelvarset_events = WAZO_CALL_PROGRESS


### PR DESCRIPTION
Why: This will mitigate load on rabbitmq

ChannelDialplan: Unused by wazo and is triggered a lot of time
ChannelVarset: Wazo doesn't use this event except for WAZO_CALL_PROGRESS
variable. So we don't need to keep other events.