### PR TITLE
remove remaining meetme.conf

### DIFF
--- a/etc/asterisk/meetme.conf
+++ b/etc/asterisk/meetme.conf
@@ -1,3 +1,0 @@
-; This file is part of the Wazo packaging and should not be modified.
-; Add files to the meetme.d directory if you wish to modify your meetme.conf
-#include meetme.d/*.conf


### PR DESCRIPTION
why: this module is not built by wazo packaging anymore
Moreover, the file reference to a non-existing file