### PR TITLE
[WAZO-4212] Enable cpp map name id channel storage backend

### DIFF
--- a/etc/asterisk/asterisk.conf
+++ b/etc/asterisk/asterisk.conf
@@ -15,3 +15,4 @@ verbose = 5
 timestamp = yes
 execincludes = yes
 highpriority = yes
+channel_storage_backend = cpp_map_name_id


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/asterisk/pull/169 
