### PR TITLE
[BUG-8] dialplan: do not send missed call notification when call is rejected

### DIFF
--- a/dialplan/extensions_lib_user.conf
+++ b/dialplan/extensions_lib_user.conf
@@ -97,6 +97,7 @@ same  =      n,Set(XIVO_VM_OPTIONS=b)
 same  =      n,Goto(forward_voicemail,1)
 
 exten = NOANSWER,1,Set(WAZO_FWD_TYPE=USER_NOANSWER)
+same  =          n,GotoIf($["${HANGUPCAUSE}" == "21"]?rejected,1)  ; 21 = rejected
 same  =          n,Gosub(notify-missed-call,1(no-answer))
 same  =          n,Goto(forward_voicemail,1)
 
@@ -105,9 +106,14 @@ same  =            n,Gosub(notify-missed-call,1(congestion))
 same  =            n,Goto(forward_voicemail,1)
 
 exten = CHANUNAVAIL,1,Set(WAZO_FWD_TYPE=USER_CHANUNAVAIL)
-same  =             n,GotoIf($["${HANGUPCAUSE}" == "21"]?BUSY,1)  ; 21 = rejected
+same  =             n,GotoIf($["${HANGUPCAUSE}" == "21"]?rejected,1)  ; 21 = rejected
 same  =             n,Gosub(notify-missed-call,1(channel-unavailable))
 same  =             n,Goto(forward_voicemail,1)
+
+exten = rejected,1,Set(WAZO_FWD_TYPE=USER_BUSY)
+same  =          n,Set(XIVO_VM_OPTIONS=b)
+same  =          n,Set(WAZO_CALL_REJECTED=1)
+same  =          n,Goto(forward_voicemail,1)
 
 exten = CLOSED,1,NoOp(User is out of schedule)
 same  =        n,Set(WAZO_FWD_TYPE=SCHEDULE_OUT)
@@ -123,8 +129,9 @@ same  =                 n,Return()
 
 exten = forward_voicemail,1,NoOp()
 same  =   n,CELGenUserEvent(XIVO_USER_FWD,NUM:${WAZO_DST_USERNUM},CONTEXT:${WAZO_DST_USER_CONTEXT},NAME:${WAZO_DST_REDIRECTING_NAME})
+same  =   n,GotoIf(${WAZO_CALL_REJECTED}?skip_missed_call_event)
 same  =   n,CELGenUserEvent(WAZO_USER_MISSED_CALL,wazo_tenant_uuid: ${WAZO_TENANT_UUID},source_user_uuid: ${WAZO_USERUUID},destination_user_uuid: ${WAZO_DST_UUID},destination_exten: ${WAZO_ENTRY_EXTEN},source_name: ${URIENCODE(${CALLERID(name)})},destination_name: ${URIENCODE(${WAZO_DST_REDIRECTING_NAME})})
-same  =   n,GotoIf(${WAZO_FROMCALLFILTER}?forward,1)
+same  =   n(skip_missed_call_event),GotoIf(${WAZO_FROMCALLFILTER}?forward,1)
 same  =   n,GotoIf($["${WAZO_FWD_REFERER_TYPE}" != "user" & "${WAZO_FWD_REFERER_TYPE}" != "group"]?forward,1)
 same  =   n,GotoIf(${XIVO_VOICEMAILVARS_ORIGIN}?forward,1:set_voicemail_origin,1)
 

--- a/dialplan/extensions_lib_user.conf
+++ b/dialplan/extensions_lib_user.conf
@@ -112,7 +112,6 @@ same  =             n,Goto(forward_voicemail,1)
 
 exten = rejected,1,Set(WAZO_FWD_TYPE=USER_BUSY)
 same  =          n,Set(XIVO_VM_OPTIONS=b)
-same  =          n,Set(WAZO_CALL_REJECTED=1)
 same  =          n,Goto(forward_voicemail,1)
 
 exten = CLOSED,1,NoOp(User is out of schedule)
@@ -129,9 +128,8 @@ same  =                 n,Return()
 
 exten = forward_voicemail,1,NoOp()
 same  =   n,CELGenUserEvent(XIVO_USER_FWD,NUM:${WAZO_DST_USERNUM},CONTEXT:${WAZO_DST_USER_CONTEXT},NAME:${WAZO_DST_REDIRECTING_NAME})
-same  =   n,GotoIf(${WAZO_CALL_REJECTED}?skip_missed_call_event)
 same  =   n,CELGenUserEvent(WAZO_USER_MISSED_CALL,wazo_tenant_uuid: ${WAZO_TENANT_UUID},source_user_uuid: ${WAZO_USERUUID},destination_user_uuid: ${WAZO_DST_UUID},destination_exten: ${WAZO_ENTRY_EXTEN},source_name: ${URIENCODE(${CALLERID(name)})},destination_name: ${URIENCODE(${WAZO_DST_REDIRECTING_NAME})})
-same  =   n(skip_missed_call_event),GotoIf(${WAZO_FROMCALLFILTER}?forward,1)
+same  =   n,GotoIf(${WAZO_FROMCALLFILTER}?forward,1)
 same  =   n,GotoIf($["${WAZO_FWD_REFERER_TYPE}" != "user" & "${WAZO_FWD_REFERER_TYPE}" != "group"]?forward,1)
 same  =   n,GotoIf(${XIVO_VOICEMAILVARS_ORIGIN}?forward,1:set_voicemail_origin,1)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, localized dialplan routing change for hangup cause 21 that only affects how rejected calls are classified and whether missed-call notifications are emitted.
> 
> **Overview**
> Treats calls rejected with `HANGUPCAUSE=21` as a dedicated `rejected` path instead of continuing through normal `NOANSWER`/`CHANUNAVAIL` handling.
> 
> The new `rejected` extension routes directly to `forward_voicemail` with busy voicemail options (and avoids calling `notify-missed-call`), preventing missed-call notifications from being sent for explicit rejections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e852ede05a5a322a3b3291d1c621896b6cbece1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->