### PR TITLE
[ITEM-205] dialplan: remove calllistening extension feature

### DIFF
--- a/dialplan/extensions_lib_features.conf
+++ b/dialplan/extensions_lib_features.conf
@@ -165,14 +165,6 @@ same  =                     n,Hangup()
 exten = incallfilterdisabled,1,Playback(screening-off)
 same  =                      n,Hangup()
 
-[calllistening]
-exten = s,1,Gosub(xivo-chk_feature_access,s,1)
-same  =   n,Set(WAZO_CHANNEL_DIRECTION=to-wazo)
-same  =   n,Gosub(xivo-pickup,0,1)
-same  =   n,Authenticate(916735)
-same  =   n,ChanSpy()
-same  =   n,Hangup()
-
 [vmbox]
 exten = s,1,GotoIf($["${ARG1}" = ""]?error,1)
 same  =   n,Set(WAZO_CHANNEL_DIRECTION=to-wazo)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk dialplan cleanup, but it removes an exposed feature entrypoint so any deployments relying on `calllistening` will no longer be able to invoke it.
> 
> **Overview**
> Removes the `calllistening` feature from `extensions_lib_features.conf`, deleting the dialplan that authenticated with a hardcoded code and invoked `ChanSpy()`.
> 
> As a result, the `calllistening` extension is no longer available as a feature entrypoint in the dialplan.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca3d0884b79170e2b8ab3d9968ca50a99c231847. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->