### PR TITLE
queues: add redirecting info

### DIFF
--- a/dialplan/extensions_lib_queue.conf
+++ b/dialplan/extensions_lib_queue.conf
@@ -71,38 +71,51 @@ same  =   n,Goto(${QUEUESTATUS},1)
 
 exten = CLOSED,1,Set(WAZO_FWD_TYPE=SCHEDULE_OUT)
 same  =        n,Set(WAZO_QUEUELOG_EVENT=CLOSED)
+same  =        n,Set(REDIRECTING(reason,i)=time_of_day)
 same  =        n,Playback(queue-closed)
 same  =        n,Goto(forward,1)
 
 exten = DIVERT,1,Set(WAZO_QUEUELOG_EVENT=${WAZO_DIVERT_EVENT})
 same  =        n,Playback(queue-diverted)
+same  =        n,Set(REDIRECTING(reason,i)=deflection)
 same  =        n,Goto(forward,1)
 
 exten = TIMEOUT,1,Set(WAZO_FWD_TYPE=QUEUE_NOANSWER)
+same  =         n,Set(REDIRECTING(reason,i)=cfnr)
 same  =         n,Playback(queue-timeout)
 same  =         n,Goto(forward,1)
 
 exten = FULL,1,Set(WAZO_FWD_TYPE=QUEUE_CONGESTION)
 same  =      n,Set(WAZO_QUEUELOG_EVENT=FULL)
+same  =      n,Set(REDIRECTING(reason,i)=cfb)
 same  =      n,Playback(queue-full)
 same  =      n,Goto(forward,1)
 
 exten = JOINEMPTY,1,Set(WAZO_FWD_TYPE=QUEUE_CHANUNAVAIL)
 same  =           n,Set(WAZO_QUEUELOG_EVENT=JOINEMPTY)
+same  =           n,Set(REDIRECTING(reason,i)=unavailable)
 same  =           n,Goto(forward,1)
 
 exten = LEAVEEMPTY,1,Set(WAZO_FWD_TYPE=QUEUE_CHANUNAVAIL)
 same  =            n,Set(WAZO_QUEUELOG_EVENT=LEAVEEMPTY)
+same  =            n,Set(REDIRECTING(reason,i)=unavailable)
 same  =            n,Goto(forward,1)
 
 exten = CONTINUE,1,Set(WAZO_FWD_TYPE=QUEUE_CHANUNAVAIL)
+same  =          n,Set(REDIRECTING(reason,i)=unavailable)
 same  =          n,Goto(forward,1)
 
 exten = forward,1,Set(__WAZO_CALLFORWARDED=1)
 same  =         n,GotoIf($["x${WAZO_QUEUELOG_EVENT}" = "x"]?noqueuelog)
 same  =         n,QueueLog(${WAZO_QUEUENAME},${UNIQUEID},NONE,${WAZO_QUEUELOG_EVENT})
-same  =         n(noqueuelog),Gosub(forward,s,1(${WAZO_FWD_${WAZO_FWD_TYPE}_ACTION},${WAZO_FWD_${WAZO_FWD_TYPE}_ACTIONARG1},${WAZO_FWD_${WAZO_FWD_TYPE}_ACTIONARG2}))
-same  =         n,Hangup()
+same  =         n(noqueuelog),NoOp()
+same  =         n,Set(REDIRECTING(count,i)=$[${REDIRECTING(count)} + 1])
+same  =         n,GotoIf($[${REDIRECTING(count)} > ${XIVO_MAX_FWD_COUNT}]?exit)
+same  =         n,Set(REDIRECTING(to-pres,i)=allowed)
+same  =         n,Set(REDIRECTING(from-name,i)=${WAZO_DST_REDIRECTING_NAME})
+same  =         n,Set(REDIRECTING(from-num,i)=${WAZO_DST_REDIRECTING_NUM})
+same  =         n,Gosub(forward,s,1(${WAZO_FWD_${WAZO_FWD_TYPE}_ACTION},${WAZO_FWD_${WAZO_FWD_TYPE}_ACTIONARG1},${WAZO_FWD_${WAZO_FWD_TYPE}_ACTIONARG2}))
+same  =         n(exit),Hangup()
 
 [wazo-queue-answered]
 exten = s,1,AGI(agi://${WAZO_AGID_IP}/queue_answered_call)

--- a/dialplan/extensions_lib_queue.conf
+++ b/dialplan/extensions_lib_queue.conf
@@ -1,4 +1,4 @@
-; Copyright 2006-2025 The Wazo Authors  (see the AUTHORS file)
+; Copyright 2006-2026 The Wazo Authors  (see the AUTHORS file)
 ; SPDX-License-Identifier: GPL-2.0+
 
 ; params:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes live queue dialplan forwarding and SIP redirect metadata; mis-set headers could affect downstream SIP endpoints or forward loops, though logic mirrors existing group forwarding.
> 
> **Overview**
> Queue call forwarding now populates **SIP `REDIRECTING`** data when a caller leaves the queue toward a forward destination, matching the pattern already used for groups.
> 
> Each queue exit path sets **`REDIRECTING(reason,i)`** before `forward` (`time_of_day`, `deflection`, `cfnr`, `cfb`, `unavailable` as appropriate). The shared **`forward`** extension increments **`REDIRECTING(count,i)`**, stops if **`XIVO_MAX_FWD_COUNT`** is exceeded, sets **`to-pres`**, **`from-name`**, and **`from-num`** from Wazo redirecting variables, then runs the existing forward Gosub before hangup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 369bc5e5d83f051d8b26dbe1c82a2e66ed9a3456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->