### PR TITLE
[ITEM-388] Unanswered call recording

### DIFF
--- a/dialplan/extensions_lib_user.conf
+++ b/dialplan/extensions_lib_user.conf
@@ -41,7 +41,6 @@ same  =   n,Set(WAZO_REAL_FROMGROUP=${IF($["${CHANNEL(channeltype)}/${WAZO_FROMG
 same  =   n,Set(WAZO_REAL_FROMQUEUE=${IF($["${CHANNEL(channeltype)}/${WAZO_FROMQUEUE}" = "Local/1"]?1:0)})
 same  =   n,AGI(agi://${WAZO_AGID_IP}/incoming_user_set_features)
 same  =   n,GoSub(wazo-setup-userevent-dial-echo,s,1)
-same  =   n,GoSub(wazo-add-pre-dial-hook,s,1(wazo-record-peer))
 
 ; schedule
 same  =   n,AGI(agi://${WAZO_AGID_IP}/check_schedule)
@@ -82,7 +81,7 @@ same  =   n,Set(__WAZO_CALLER_NAME=${CALLERID(name)})
 same  =   n,Set(WAZO_IS_CALLER=1)
 same  =   n,Set(__WAZO_CALLEE_NUM=${WAZO_DSTNUM})
 same  =   n,Set(__WAZO_CALLEE_NAME=${WAZO_DST_NAME})
-same  =   n,Dial(${WAZO_INTERFACE},${WAZO_RINGSECONDS},${WAZO_CALLOPTIONS})
+same  =   n,Dial(${WAZO_INTERFACE},${WAZO_RINGSECONDS},${WAZO_CALLOPTIONS}U(wazo-record-peer))
 same  =   n,Goto(${DIALSTATUS},1)
 same  =   n,Return()
 
@@ -141,7 +140,7 @@ same  =        n,Goto(forward,1)
 exten = dial_from_queue,1,GotoIf(${WAZO_ENABLEDND}?busy)
 same  =                 n,GotoIf(${WAZO_ENABLEUNC}?busy)
 same  =                 n,GoSub(wazo-schedule-pre-dial-hooks,s,1)
-same  =                 n,Dial(${WAZO_INTERFACE},,${WAZO_CALLOPTIONS})
+same  =                 n,Dial(${WAZO_INTERFACE},,${WAZO_CALLOPTIONS}U(wazo-record-peer))
 same  =                 n(busy),Busy()
 same  =                 n,Return()
 


### PR DESCRIPTION
Peer/incoming recording was started from a pre-dial hook (the b() Dial
option scheduled via wazo-add-pre-dial-hook), which runs on the callee leg
while it is still ringing. MixMonitor therefore created an (empty) recording
file even for calls that were never answered.

Start it from the U() post-answer Dial option instead, reusing the existing
wazo-record-peer subroutine and start_mix_monitor AGI unchanged. Both b() and
U() run their gosub on the same callee leg, so answered calls record exactly
as before; only the start moves from ring time to answer time, so no file is
created when the call is not answered. This mirrors how groups and queues
already start recording on answer (U(wazo-group-answered)).

ITEM-388

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dialplan-only change to recording start timing; answered-call recording path is preserved and aligns with existing queue/group patterns.
> 
> **Overview**
> Fixes **empty peer/incoming recording files** when a user never answers by moving when `wazo-record-peer` runs.
> 
> Recording is **no longer registered** via `wazo-add-pre-dial-hook` (pre-dial / `b()` on the callee leg while ringing). Both user `Dial()` paths—normal ring and `dial_from_queue`—now append **`U(wazo-record-peer)`** so `start_mix_monitor` runs only **after answer**, still on the callee leg. The `wazo-record-peer` subroutine and AGI are unchanged; behavior for answered calls should match prior recording, without creating a file for unanswered attempts (same idea as group/queue `U(wazo-group-answered)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2aa7875560539b7bf1ae38a0b85ca655fe3ea8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->