### PR TITLE
Revert "[ITEM-388] Unanswered call recording"

### DIFF
--- a/dialplan/extensions_lib_user.conf
+++ b/dialplan/extensions_lib_user.conf
@@ -41,6 +41,7 @@ same  =   n,Set(WAZO_REAL_FROMGROUP=${IF($["${CHANNEL(channeltype)}/${WAZO_FROMG
 same  =   n,Set(WAZO_REAL_FROMQUEUE=${IF($["${CHANNEL(channeltype)}/${WAZO_FROMQUEUE}" = "Local/1"]?1:0)})
 same  =   n,AGI(agi://${WAZO_AGID_IP}/incoming_user_set_features)
 same  =   n,GoSub(wazo-setup-userevent-dial-echo,s,1)
+same  =   n,GoSub(wazo-add-pre-dial-hook,s,1(wazo-record-peer))
 
 ; schedule
 same  =   n,AGI(agi://${WAZO_AGID_IP}/check_schedule)
@@ -81,7 +82,7 @@ same  =   n,Set(__WAZO_CALLER_NAME=${CALLERID(name)})
 same  =   n,Set(WAZO_IS_CALLER=1)
 same  =   n,Set(__WAZO_CALLEE_NUM=${WAZO_DSTNUM})
 same  =   n,Set(__WAZO_CALLEE_NAME=${WAZO_DST_NAME})
-same  =   n,Dial(${WAZO_INTERFACE},${WAZO_RINGSECONDS},${WAZO_CALLOPTIONS}U(wazo-record-peer))
+same  =   n,Dial(${WAZO_INTERFACE},${WAZO_RINGSECONDS},${WAZO_CALLOPTIONS})
 same  =   n,Goto(${DIALSTATUS},1)
 same  =   n,Return()
 
@@ -140,7 +141,7 @@ same  =        n,Goto(forward,1)
 exten = dial_from_queue,1,GotoIf(${WAZO_ENABLEDND}?busy)
 same  =                 n,GotoIf(${WAZO_ENABLEUNC}?busy)
 same  =                 n,GoSub(wazo-schedule-pre-dial-hooks,s,1)
-same  =                 n,Dial(${WAZO_INTERFACE},,${WAZO_CALLOPTIONS}U(wazo-record-peer))
+same  =                 n,Dial(${WAZO_INTERFACE},,${WAZO_CALLOPTIONS})
 same  =                 n(busy),Busy()
 same  =                 n,Return()
 


### PR DESCRIPTION
Reverts wazo-platform/wazo-asterisk-config#79

This breaks automatic call recording.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live user and queue-member dial paths where call recording is started; wrong wiring would affect compliance-sensitive recordings but the change is a targeted revert of a known-bad approach.
> 
> **Overview**
> Reverts the ITEM-388 unanswered-call recording approach in the user dialplan so **automatic peer call recording** works again.
> 
> **Registration:** After `incoming_user_set_features`, the flow again calls `GoSub(wazo-add-pre-dial-hook,s,1(wazo-record-peer))`, so `wazo-record-peer` is queued on `_WAZO_PRE_DIAL_HANDLERS` and runs through `wazo-schedule-pre-dial-hooks` / `wazo-pre-dial-hooks` before the callee leg is connected.
> 
> **Dial options:** `U(wazo-record-peer)` is removed from both normal user `Dial` and `dial_from_queue` `Dial`, leaving recording to the pre-dial hook path instead of Asterisk’s Dial `U` option on the peer channel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2b55b1fb2718990d6e051dad45e51b8ac26907f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->