### PR TITLE
context: fix simultcalls string comparison

### DIFF
--- a/dialplan/extensions_lib_context.conf
+++ b/dialplan/extensions_lib_context.conf
@@ -1,4 +1,4 @@
-; Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
+; Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 ; SPDX-License-Identifier: GPL-3.0+
 
 [contextlib]
@@ -15,14 +15,14 @@ exten = s,1,NoOp(Counting calls for ${ARG1}@WAZO_USER)
 same  =   n,GotoIf($[${ARG1}]?:end)
 same  =   n,GotoIf($["${ARG1}" == "-1"]?no_caller)
 same  =   n,GotoIf($["${WAZO_CALLER_SIMULTCALLS}" == ""]?no_caller)
-same  =   n,GotoIf($["${GROUP_COUNT(${ARG1}@WAZO_USER)}" >= "${WAZO_CALLER_SIMULTCALLS}"]?caller_full)
+same  =   n,GotoIf($[${GROUP_COUNT(${ARG1}@WAZO_USER)} >= ${WAZO_CALLER_SIMULTCALLS}]?caller_full)
 same  =   n,Set(GROUP(WAZO_USER)=${ARG1})
 
 same  =   n(no_caller),GotoIf($[${EXISTS(${ARG2})}]?:end)
 
 same  =   n,NoOp(Counting calls for destination ${ARG2}@WAZO_USER)
 same  =   n,GotoIf($["${WAZO_CALLEE_SIMULTCALLS}" == ""]?end)
-same  =   n,GotoIf($["${GROUP_COUNT(${ARG2}@WAZO_USER)}" >= "${WAZO_CALLEE_SIMULTCALLS}"]?dest_full)
+same  =   n,GotoIf($[${GROUP_COUNT(${ARG2}@WAZO_USER)} >= ${WAZO_CALLEE_SIMULTCALLS}]?dest_full)
 same  =   n,Set(OUTBOUND_GROUP_ONCE=${ARG2}@WAZO_USER)
 
 same  =   n(end),Return(0)


### PR DESCRIPTION
Why: 12 < 2 when a string but it's not what we want.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dialplan expression change in call-limit logic; corrects behavior with low blast radius.
> 
> **Overview**
> Fixes **simultaneous call limit** checks in the `[callcounter]` context so limits are compared as numbers, not strings.
> 
> The `GotoIf` conditions for caller and callee limits no longer wrap `${WAZO_CALLER_SIMULTCALLS}` and `${WAZO_CALLEE_SIMULTCALLS}` in quotes inside `$[...]`, avoiding lexicographic comparison (e.g. `12` incorrectly treated as less than `2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13fff1827387ebf230fc8bb27b6ed60210a8d6b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->